### PR TITLE
Fix Issue #3 bug: Nullable Property Types don't work

### DIFF
--- a/src/CherryPicker/PropertySetterInstancePolicy.cs
+++ b/src/CherryPicker/PropertySetterInstancePolicy.cs
@@ -17,7 +17,8 @@ namespace CherryPicker
             foreach (var propertyDefault in propertyDefaults)
             {
                 var property = instance.SettableProperties().FirstOrDefault(prop => prop.Name == propertyDefault.Key);
-                instance.Dependencies.AddForProperty(property, propertyDefault.Value);
+                var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+                instance.Dependencies.Add(property.Name, propertyType, propertyDefault.Value);
             }
         }
     }

--- a/src/CherryPickerTests/TestClasses/NullableTypeClass.cs
+++ b/src/CherryPickerTests/TestClasses/NullableTypeClass.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CherryPickerTests.TestClasses
+{
+    public class NullableTypeClass
+    {
+        public int? NullableInt { get; set; }
+    }
+}

--- a/src/CherryPickerTests/TestDataContainerTests.cs
+++ b/src/CherryPickerTests/TestDataContainerTests.cs
@@ -117,6 +117,26 @@ namespace CherryPickerTests
         }
 
         [Fact]
+        public void When_a_built_objects_properties_are_nullable_types_Then_no_exception_is_thrown_when_setting_those_properties()
+        {
+            _container.For<NullableTypeClass>(x => x
+                .Default(nt => nt.NullableInt).To(3));
+
+            var nullableTypeClass = _container.Build<NullableTypeClass>();
+
+            Assert.True(nullableTypeClass.NullableInt == 3);
+        }
+
+        [Fact]
+        public void When_a_nullable_type_property_default_is_overriden_Then_no_exception_is_thrown_when_setting_those_properties()
+        {
+            var nullableTypeClass = _container.Build<NullableTypeClass>(x => x
+                .Set(nt => nt.NullableInt).To(3));
+
+            Assert.True(nullableTypeClass.NullableInt == 3);
+        }
+
+        [Fact]
         public void When_a_non_value_type_property_is_overriden_Then_the_defaults_are_not_used()
         {
             _container.For<Vehicle>(


### PR DESCRIPTION
Nullable's underlying type used to define property's type instead of StructureMap inferring the type from the property directly